### PR TITLE
use View.maybeOf to resolve viewInsets.bottom always 0.0 on some devices when keyboard is open

### DIFF
--- a/lib/src/keyboard_detection.dart
+++ b/lib/src/keyboard_detection.dart
@@ -91,7 +91,7 @@ class _KeyboardDetectionState extends State<KeyboardDetection>
       return;
     }
 
-    final viewInsets = MediaQuery.maybeViewInsetsOf(context);
+    final viewInsets = View.maybeOf(context)?.viewInsets;
     if (viewInsets == null) {
       return;
     }


### PR DESCRIPTION
This PR fixes an issue where MediaQuery.maybeViewInsetsOf(context).viewInsets.bottom returns 0.0 on some devices when the keyboard is open. Switched to View.maybeOf(context)?.viewInsets for more reliable behavior.